### PR TITLE
Include /etc/mysql/conf.d for Red Hat

### DIFF
--- a/role.yml
+++ b/role.yml
@@ -1,0 +1,11 @@
+---
+# Testing role for Travis
+- hosts: localhost
+  remote_user: root
+  vars_files:
+    - 'vars/main.yml'
+    - 'defaults/main.yml'
+  tasks:
+    - include: 'tasks/main.yml'
+  handlers:
+    - include: 'handlers/main.yml'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,11 @@
   notify:
    - restart mysql
 
+- name: Create the directory /etc/mysql/conf.d
+  file: path=/etc/mysql/conf.d state=directory
+  notify:
+   - restart mysql
+
 - name: ensure mysql service has started/stopped
   service: name={{ mysql_service }} state={{ mysql_state }} enabled={{ mysql_enabled }}
 

--- a/templates/my.cnf.RedHat.j2
+++ b/templates/my.cnf.RedHat.j2
@@ -37,3 +37,5 @@ binlog_ignore_db={{ i.name }}
 [mysqld_safe]
 log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
+
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
Reintroduces an old commit from @bennojoy's role. 

Ensures /etc/mysql/conf.d exists, and include it in the my.cnf used for Red Hat (the Debian version already contains that line)