### PR TITLE
Remove env variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,9 @@
 - name: Install the mysql packages in Debian derivatives
   apt: name={{ item }} state=installed
   with_items: mysql_pkgs
-  environment: env
+  environment:
+    # see e.g. http://askubuntu.com/a/75560
+    RUNLEVEL: 1
   when: ansible_os_family == 'Debian'
 
 - name: create datadir if different to default

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-env:
- RUNLEVEL: 1


### PR DESCRIPTION
Avoid clashes with env variable set elsewhere and just hardcode
its only use.

Appears to be a Debian fix to allow installation without starting
a service.