### PR TITLE
Switch to generic repository package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,8 @@ mysql_data_dir: /var/lib/mysql
 mysql_state: started
 mysql_enabled: 'yes'
 mysql_community_server: false
-# Currently supported 56 or 57
-mysql_community_server_version: "5.6"
+# Currently supported: 55, 56, 57 (corresponding to 5.5, 5.6, 5.7)
+mysql_community_server_version: 56
 
 mysql_configs:
 - { name: 'query_cache_limit', value: '16M'}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,16 +23,11 @@
     state: installed
   when: ansible_os_family == 'RedHat' and mysql_community_server == true
 
-- name: disable the latest community repository
-  yum_repository:
-    name: mysql80-community
-    enabled: no
-  when: ansible_os_family == 'RedHat' and mysql_community_server == true
-
 - name: install the mysql packages in Redhat derivatives
   yum:
     name: "{{mysql_pkgs}}"
-    enablerepo: "{{ 'mysql' + mysql_community_server_version + '-community' if mysql_community_server else omit }}"
+    enablerepo: "{{ 'mysql' + mysql_community_server_version|string + '-community' if mysql_community_server else omit }}"
+    disablerepo: "{{ 'mysql80-community' if mysql_community_server and mysql_community_server_version != 80 else omit}}"
     state: installed
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,13 +17,15 @@
   when: ansible_os_family == 'RedHat' and mysql_community_server == true
 
 - name: install the mysql packages in Redhat derivatives
-  yum: name={{ item }} state=installed
-  with_items: "{{mysql_pkgs}}"
+  yum:
+    name: "{{mysql_pkgs}}"
+    state: installed
   when: ansible_os_family == 'RedHat'
 
 - name: Install the mysql packages in Debian derivatives
-  apt: name={{ item }} state=installed
-  with_items: "{{mysql_pkgs}}"
+  apt:
+    name: "{{mysql_pkgs}}"
+    state: installed
   environment:
     # see e.g. http://askubuntu.com/a/75560
     RUNLEVEL: 1
@@ -63,7 +65,7 @@
 - name: use temporary password for root user
   set_fact:
     mysql_root_tmp_db_pass: "{{ mysql_tmp_root_passwort.stdout }}"
-  when: not mysql_tmp_root_passwort|skipped
+  when: mysql_tmp_root_passwort is not skipped
 
 - name: update mysql root password for localhost root account (5.7.x).
   shell: 'mysql -e "SET PASSWORD = PASSWORD(''{{ mysql_root_db_pass }}'');" --connect-expired-password -uroot -p"{{ mysql_root_tmp_db_pass }}"'
@@ -127,15 +129,15 @@
 
 - name: ensure the hostname entry for master is available for the client
   lineinfile: dest=/etc/hosts regexp="{{ mysql_repl_master }}" line="{{ mysql_repl_master + '   ' +  hostvars[mysql_repl_master].ansible_default_ipv4.address }}" state=present
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
 
 - name: get the current master servers replication status
   mysql_replication: mode=getmaster
   delegate_to: "{{ mysql_repl_master }}"
   register: repl_stat
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
 
 - name: change the master in slave to start the replication
   mysql_replication: mode=changemaster master_host={{ mysql_repl_master }} master_log_file={{ repl_stat.File }} master_log_pos={{ repl_stat.Position }} master_user={{ mysql_repl_user[0].name }} master_password={{ mysql_repl_user[0].pass }}
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
   no_log: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,18 +7,32 @@
   when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int == 7
 
 - name: add variables for MySQL Community Server on RedHad derivates
-  include_vars: RedHat_community_server_{{ mysql_community_server_version }}.yml
+  include_vars: RedHat_community_server.yml
+  when: ansible_os_family == 'RedHat' and mysql_community_server == true
+
+- name: fetch community rpm package for CentOS
+  get_url:
+    url: "{{ mysql_community_server_repo }}"
+    checksum: "{{ mysql_community_server_repo_checksum }}"
+    dest: "/tmp/mysql-community-release.rpm"
   when: ansible_os_family == 'RedHat' and mysql_community_server == true
 
 - name: install community yum repo
   yum:
-    name: "{{ mysql_community_server_repo }}"
+    name: "/tmp/mysql-community-release.rpm"
     state: installed
+  when: ansible_os_family == 'RedHat' and mysql_community_server == true
+
+- name: disable the latest community repository
+  yum_repository:
+    name: mysql80-community
+    enabled: no
   when: ansible_os_family == 'RedHat' and mysql_community_server == true
 
 - name: install the mysql packages in Redhat derivatives
   yum:
     name: "{{mysql_pkgs}}"
+    enablerepo: "{{ 'mysql' + mysql_community_server_version + '-community' if mysql_community_server else omit }}"
     state: installed
   when: ansible_os_family == 'RedHat'
 

--- a/vars/RedHat_community_server.yml
+++ b/vars/RedHat_community_server.yml
@@ -1,0 +1,8 @@
+---
+mysql_community_server_repo: "https://dev.mysql.com/get/mysql80-community-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+mysql_community_server_repo_md5sum: "{{ 'md5:f2befc44a4b8416864987b1686c4a72b' if ansible_distribution_major_version|int == 6 else 'md5:739dc44566d739c5d7b893de96ee6848' }}"
+mysql_pkgs:
+  - libselinux-python
+  - mysql-community-server
+  - MySQL-python
+mysql_service: mysqld

--- a/vars/RedHat_community_server.yml
+++ b/vars/RedHat_community_server.yml
@@ -1,6 +1,6 @@
 ---
 mysql_community_server_repo: "https://dev.mysql.com/get/mysql80-community-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
-mysql_community_server_repo_md5sum: "{{ 'md5:f2befc44a4b8416864987b1686c4a72b' if ansible_distribution_major_version|int == 6 else 'md5:739dc44566d739c5d7b893de96ee6848' }}"
+mysql_community_server_repo_checksum: "{{ 'md5:f2befc44a4b8416864987b1686c4a72b' if ansible_distribution_major_version|int == 6 else 'md5:739dc44566d739c5d7b893de96ee6848' }}"
 mysql_pkgs:
   - libselinux-python
   - mysql-community-server

--- a/vars/RedHat_community_server_5.6.yml
+++ b/vars/RedHat_community_server_5.6.yml
@@ -1,7 +1,0 @@
----
-mysql_community_server_repo: "http://dev.mysql.com/get/mysql-community-release-el{{ ansible_distribution_major_version }}-5.noarch.rpm"
-mysql_pkgs:
-  - libselinux-python
-  - mysql-community-server
-  - MySQL-python
-mysql_service: mysql

--- a/vars/RedHat_community_server_5.7.yml
+++ b/vars/RedHat_community_server_5.7.yml
@@ -1,7 +1,0 @@
----
-mysql_community_server_repo: "http://dev.mysql.com/get/mysql57-community-release-el{{ ansible_distribution_major_version }}-9.noarch.rpm"
-mysql_pkgs:
-  - libselinux-python
-  - mysql-community-server
-  - MySQL-python
-mysql_service: mysqld


### PR DESCRIPTION
It looks like upstream no longer supports individual RPM repo packages for each MySQL community release.

This PR pulls in the generic MySQL 8.0 repo package and selects the correct repo on package installation. It also verifies the RPM checksum before installing it.

Only MySQL 5.5 on CentOS 7 has been tested so far.